### PR TITLE
Fix typo in env_frontend.j2

### DIFF
--- a/templates/env_frontend.j2
+++ b/templates/env_frontend.j2
@@ -8,7 +8,7 @@ FUNKWHALE_API_HOST={{ funkwhale_api_identifier }}
 FUNKWHALE_API_PORT={{ funkwhale_api_container_port }}
 
 MEDIA_ROOT=/srv/funkwhale/data/media
-MUSIC_DIRECTORY_PATH=/src/funkwhale/data/music
+MUSIC_DIRECTORY_PATH=/srv/funkwhale/data/music
 
 FUNKWHALE_WEB_WORKERS={{ funkwhale_frontend_web_workers }}
 


### PR DESCRIPTION
Fixing a typo preventing `mash-funkwhale-frontend` accessing the in-place import folder at `/srv/funkwhale/data/music`.