### PR TITLE
Add mash-funkwhale-watch-imports.service to watch for library updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,11 @@ funkwhale_media_path: "{{ funkwhale_data_path }}/media"
 # The `funkwhale_music_path` defines a place where you can put music that can then be imported into funkwhale.
 funkwhale_music_path: "{{ funkwhale_data_path }}/music"
 
+# Enables automatic in-place import and watching file and metadata changes in the funkwhale_music_path directory.
+# Needs the first 8 characters of the library ID after creating a library in the web UI. If your library ID is "769a2bc3-eb1d-4aff-9f84-2c4d80d5c2d1", provide "769a2bc3".
+funkwhale_watch_imports_enabled: false
+funkwhale_watch_imports_library_id: ""  # add first 8 characters of library ID here
+
 funkwhale_frontend_static_path: "{{ funkwhale_frontend_base_path }}/appstatic"
 
 funkwhale_frontend_env_path: "{{ funkwhale_frontend_base_path }}/env"
@@ -435,3 +440,25 @@ funkwhale_celery_worker_variables_additional_variables: ''
 funkwhale_celery_worker_process_extra_arguments: "{{ funkwhale_celery_worker_process_extra_arguments_auto + funkwhale_celery_worker_process_extra_arguments_custom }}"
 funkwhale_celery_worker_process_extra_arguments_auto: []
 funkwhale_celery_worker_process_extra_arguments_custom: []
+
+
+###################
+## WATCH-IMPORTS ##
+###################
+
+funkwhale_watch_imports_identifier: "{{ funkwhale_identifier }}-watch-imports"
+
+funkwhale_watch_imports_systemd_required_services_list: ['docker.service', '{{ funkwhale_api_identifier }}.service']
+
+funkwhale_watch_imports_container_network: '{{ funkwhale_container_network }}'
+
+# A list of additional container networks that the container would be connected to.
+# The role does not create these networks, so make sure they already exist.
+# Use this to expose this container to a reverse proxy, which runs in a different container network.
+funkwhale_watch_imports_container_additional_networks: []
+
+# A list of extra arguments to pass to the Funkwhale watch imports process
+# Example: ['--prune', '--replace']
+funkwhale_watch_imports_process_extra_arguments: "{{ funkwhale_watch_imports_process_extra_arguments_auto + funkwhale_watch_imports_process_extra_arguments_custom }}"
+funkwhale_watch_imports_process_extra_arguments_auto: []
+funkwhale_watch_imports_process_extra_arguments_custom: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,6 +96,10 @@ funkwhale_api_container_image_tag: "{{ funkwhale_api_version }}"
 funkwhale_api_container_image_force_pull: "{{ funkwhale_api_container_image.endswith(':latest') }}"
 
 funkwhale_api_container_data_path: "/srv/funkwhale/data"
+funkwhale_api_container_media_path: "{{ funkwhale_api_container_data_path }}/media"
+funkwhale_api_container_music_path: "{{ funkwhale_api_container_data_path }}/music"
+funkwhale_api_container_static_path: "{{ funkwhale_api_container_data_path }}/static"
+
 
 funkwhale_api_container_network: '{{ funkwhale_container_network }}'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -95,9 +95,11 @@ funkwhale_api_container_image_registry_prefix: "{{ funkwhale_container_image_reg
 funkwhale_api_container_image_tag: "{{ funkwhale_api_version }}"
 funkwhale_api_container_image_force_pull: "{{ funkwhale_api_container_image.endswith(':latest') }}"
 
+funkwhale_api_container_data_path: "/srv/funkwhale/data"
+
 funkwhale_api_container_network: '{{ funkwhale_container_network }}'
 
-# Increase this if you want to upload a lot of audio files via the web GUI and get "Can' upload file, ensure it's not to big"
+# Increase this if you want to upload a lot of audio files via the web GUI and get "Can't upload file, ensure it's not to big"
 funkwhale_api_tmpfs_size: 5000m
 
 funkwhale_api_container_port: 5000
@@ -254,6 +256,10 @@ funkwhale_frontend_container_image: "{{ funkwhale_frontend_container_image_regis
 funkwhale_frontend_container_image_registry_prefix: "{{ funkwhale_container_image_registry_prefix }}"
 funkwhale_frontend_container_image_tag: "{{ funkwhale_frontend_version }}"
 funkwhale_frontend_container_image_force_pull: "{{ funkwhale_frontend_container_image.endswith(':latest') }}"
+
+funkwhale_frontend_container_media_path: "/srv/funkwhale/data/media"
+funkwhale_frontend_container_music_path: "/srv/funkwhale/data/music"
+funkwhale_frontend_container_static_path: "/usr/share/nginx/html/staticfiles"
 
 funkwhale_frontend_container_network: '{{ funkwhale_container_network }}'
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -81,8 +81,8 @@
     - {src: "{{ role_path }}/templates/systemd/funkwhale-watch-imports.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service", when: funkwhale_watch_imports_enabled}
 
 - name: Ensure disabled funkwhale services are stopped and removed
+  when: not funkwhale_watch_imports_enabled
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_service.yml"
   with_items:
     - service: "{{ funkwhale_watch_imports_identifier }}.service"
       path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service"
-      when: not funkwhale_watch_imports_enabled

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -86,3 +86,4 @@
   with_items:
     - service: "{{ funkwhale_watch_imports_identifier }}.service"
       path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service"
+

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -80,7 +80,7 @@
     - {src: "{{ role_path }}/templates/systemd/funkwhale-celery-worker.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_celery_worker_identifier }}.service"}
     - {src: "{{ role_path }}/templates/systemd/funkwhale-watch-imports.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service", when: funkwhale_watch_imports_enabled}
 
-- name: Ensure disabled funkwhale services are stopped and removed
+- name: Ensure disabled funkwhale watch imports service is stopped and removed
   when: not funkwhale_watch_imports_enabled
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_service.yml"
   with_items:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -82,6 +82,7 @@
 
 - name: Ensure disabled funkwhale services are stopped and removed
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_service.yml"
-  - service: "{{ funkwhale_watch_imports_identifier }}.service"
+  with_items:
+    - service: "{{ funkwhale_watch_imports_identifier }}.service"
       path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service"
       when: not funkwhale_watch_imports_enabled

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -82,5 +82,6 @@
 
 - name: Ensure disabled funkwhale services are stopped and removed
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_service.yml"
-  with_items:
-    - {service: "{{ funkwhale_watch_imports_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service", when: not funkwhale_watch_imports_enabled}
+  - service: "{{ funkwhale_watch_imports_identifier }}.service"
+      path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service"
+      when: not funkwhale_watch_imports_enabled

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -78,3 +78,4 @@
     - {src: "{{ role_path }}/templates/systemd/funkwhale-api.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_api_identifier }}.service"}
     - {src: "{{ role_path }}/templates/systemd/funkwhale-celery-beat.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_celery_beat_identifier }}.service"}
     - {src: "{{ role_path }}/templates/systemd/funkwhale-celery-worker.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_celery_worker_identifier }}.service"}
+    - {src: "{{ role_path }}/templates/systemd/funkwhale-watch-imports.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service", when: funkwhale_watch_imports_enabled}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -79,3 +79,8 @@
     - {src: "{{ role_path }}/templates/systemd/funkwhale-celery-beat.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_celery_beat_identifier }}.service"}
     - {src: "{{ role_path }}/templates/systemd/funkwhale-celery-worker.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_celery_worker_identifier }}.service"}
     - {src: "{{ role_path }}/templates/systemd/funkwhale-watch-imports.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service", when: funkwhale_watch_imports_enabled}
+
+- name: Ensure disabled funkwhale services are stopped and removed
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_service.yml"
+  with_items:
+    - {service: "{{ funkwhale_watch_imports_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service", when: not funkwhale_watch_imports_enabled}

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -5,7 +5,10 @@
   with_items:
     - {service: "{{ funkwhale_frontend_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_frontend_identifier }}.service"}
     - {service: "{{ funkwhale_api_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_api_identifier }}.service"}
-    - {service: "{{ funkwhale_watch_imports_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service", when: funkwhale_watch_imports_enabled}
+    - {service: "{{ funkwhale_celery_worker_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_celery_worker_identifier }}.service"}
+    - {service: "{{ funkwhale_celery_beat_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_celery_beat_identifier }}.service"}
+    - {service: "{{ funkwhale_watch_imports_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service"}
+
 
 - name: Ensure funkwhale base path is files deleted
   ansible.builtin.file:

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -5,6 +5,7 @@
   with_items:
     - {service: "{{ funkwhale_frontend_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_frontend_identifier }}.service"}
     - {service: "{{ funkwhale_api_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_api_identifier }}.service"}
+    - {service: "{{ funkwhale_watch_imports_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ funkwhale_watch_imports_identifier }}.service", when: funkwhale_watch_imports_enabled}
 
 - name: Ensure funkwhale base path is files deleted
   ansible.builtin.file:

--- a/templates/env_api.j2
+++ b/templates/env_api.j2
@@ -46,13 +46,13 @@ CACHE_URL={{ funkwhale_config_redis_url }}
 CELERY_BROKER_URL={{ funkwhale_config_redis_url }}
 
 # Media root inside the container
-MEDIA_ROOT=/srv/funkwhale/data/media
+MEDIA_ROOT={{ funkwhale_api_container_data_path }}/media
 
 # Static root inside the container
-STATIC_ROOT=/srv/funkwhale/data/static
+STATIC_ROOT={{ funkwhale_api_container_data_path }}/static
 
 # Music directory inside the container
-MUSIC_DIRECTORY_PATH=/srv/funkwhale/data/music
+MUSIC_DIRECTORY_PATH={{ funkwhale_api_container_data_path }}/music
 
 # which settings module should django use?
 # You don't have to touch this unless you really know what you're doing

--- a/templates/env_api.j2
+++ b/templates/env_api.j2
@@ -46,13 +46,13 @@ CACHE_URL={{ funkwhale_config_redis_url }}
 CELERY_BROKER_URL={{ funkwhale_config_redis_url }}
 
 # Media root inside the container
-MEDIA_ROOT={{ funkwhale_api_container_data_path }}/media
+MEDIA_ROOT={{ funkwhale_api_container_media_path }}
 
 # Static root inside the container
-STATIC_ROOT={{ funkwhale_api_container_data_path }}/static
+STATIC_ROOT={{ funkwhale_api_container_static_path }}
 
 # Music directory inside the container
-MUSIC_DIRECTORY_PATH={{ funkwhale_api_container_data_path }}/music
+MUSIC_DIRECTORY_PATH={{ funkwhale_api_container_music_path }}
 
 # which settings module should django use?
 # You don't have to touch this unless you really know what you're doing

--- a/templates/env_frontend.j2
+++ b/templates/env_frontend.j2
@@ -7,8 +7,8 @@ FUNKWHALE_PROTOCOL=https
 FUNKWHALE_API_HOST={{ funkwhale_api_identifier }}
 FUNKWHALE_API_PORT={{ funkwhale_api_container_port }}
 
-MEDIA_ROOT=/srv/funkwhale/data/media
-MUSIC_DIRECTORY_PATH=/srv/funkwhale/data/music
+MEDIA_ROOT={{ funkwhale_frontend_container_media_path }}
+MUSIC_DIRECTORY_PATH={{ funkwhale_frontend_container_music_path }}
 
 FUNKWHALE_WEB_WORKERS={{ funkwhale_frontend_web_workers }}
 

--- a/templates/systemd/funkwhale-api.service.j2
+++ b/templates/systemd/funkwhale-api.service.j2
@@ -22,7 +22,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
                 {% endif %}
                 --label-file={{ funkwhale_api_base_path }}/labels \
                 --network={{ funkwhale_api_container_network }} \
-                --mount type=bind,src={{ funkwhale_data_path }},dst={{ funkwhale_api_container_data_path }} \
+                --mount type=bind,src={{ funkwhale_music_path }},dst={{ funkwhale_api_container_music_path }},readonly \
+                --mount type=bind,src={{ funkwhale_media_path }},dst={{ funkwhale_api_container_media_path }} \
+                --mount type=bind,src={{ funkwhale_static_path }},dst={{ funkwhale_api_container_static_path }} \
                 --tmpfs=/tmp:rw,noexec,nosuid,size={{ funkwhale_api_tmpfs_size }} \
                 --read-only \
                 --env-file={{ funkwhale_api_env_path }} \

--- a/templates/systemd/funkwhale-api.service.j2
+++ b/templates/systemd/funkwhale-api.service.j2
@@ -22,7 +22,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
                 {% endif %}
                 --label-file={{ funkwhale_api_base_path }}/labels \
                 --network={{ funkwhale_api_container_network }} \
-                --mount type=bind,src={{ funkwhale_data_path }},dst=/srv/funkwhale/data \
+                --mount type=bind,src={{ funkwhale_data_path }},dst={{ funkwhale_api_container_data_path }} \
                 --tmpfs=/tmp:rw,noexec,nosuid,size={{ funkwhale_api_tmpfs_size }} \
                 --read-only \
                 --env-file={{ funkwhale_api_env_path }} \

--- a/templates/systemd/funkwhale-frontend.service.j2
+++ b/templates/systemd/funkwhale-frontend.service.j2
@@ -25,9 +25,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
                 {% endif %}
                 --label-file={{ funkwhale_frontend_base_path }}/labels \
                 --network={{ funkwhale_frontend_container_network }} \
-                --mount type=bind,src={{ funkwhale_music_path }},dst=/srv/funkwhale/data/music,readonly \
-                --mount type=bind,src={{ funkwhale_media_path }},dst=/srv/funkwhale/data/media,readonly \
-                --mount type=bind,src={{ funkwhale_static_path }},dst=/usr/share/nginx/html/staticfiles,readonly \
+                --mount type=bind,src={{ funkwhale_music_path }},dst={{ funkwhale_frontend_container_music_path }},readonly \
+                --mount type=bind,src={{ funkwhale_media_path }},dst={{ funkwhale_frontend_container_media_path }},readonly \
+                --mount type=bind,src={{ funkwhale_static_path }},dst={{ funkwhale_frontend_container_static_path }},readonly \
                 --env-file={{ funkwhale_frontend_env_path }} \
                 {% if funkwhale_frontend_container_extra_arguments | length > 0 %}
                 {{ funkwhale_frontend_container_extra_arguments | join(' ') }} \

--- a/templates/systemd/funkwhale-watch-imports.service.j2
+++ b/templates/systemd/funkwhale-watch-imports.service.j2
@@ -11,7 +11,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} exec {{ funkw
     funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_data_path }}/music --recursive --noinput --in-place {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} exec {{ funkwhale_api_identifier }} \
-    funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_data_path }}/music --recursive --noinput --in-place --watch {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
+    funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_music_path }} --recursive --noinput --in-place --watch {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
 
 Restart=always
 RestartSec=30

--- a/templates/systemd/funkwhale-watch-imports.service.j2
+++ b/templates/systemd/funkwhale-watch-imports.service.j2
@@ -8,7 +8,7 @@ DefaultDependencies=no
 [Service]
 Type=simple
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} exec {{ funkwhale_api_identifier }} \
-    funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_data_path }}/music --recursive --noinput --in-place {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
+    funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_music_path }} --recursive --noinput --in-place {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} exec {{ funkwhale_api_identifier }} \
     funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_music_path }} --recursive --noinput --in-place --watch {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}

--- a/templates/systemd/funkwhale-watch-imports.service.j2
+++ b/templates/systemd/funkwhale-watch-imports.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Funkwhale Watch Imports Service ({{ funkwhale_watch_imports_identifier }})
+Requires={{ funkwhale_api_identifier }}.service
+After={{ funkwhale_api_identifier }}.service
+DefaultDependencies=no
+
+
+[Service]
+Type=simple
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} exec {{ funkwhale_api_identifier }} \
+    funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} /srv/funkwhale/data/music --recursive --noinput --in-place --watch {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
+
+Restart=always
+RestartSec=30
+SyslogIdentifier={{ funkwhale_watch_imports_identifier }}

--- a/templates/systemd/funkwhale-watch-imports.service.j2
+++ b/templates/systemd/funkwhale-watch-imports.service.j2
@@ -7,6 +7,9 @@ DefaultDependencies=no
 
 [Service]
 Type=simple
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} exec {{ funkwhale_api_identifier }} \
+    funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_data_path }}/music --recursive --noinput --in-place {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
+
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} exec {{ funkwhale_api_identifier }} \
     funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_data_path }}/music --recursive --noinput --in-place --watch {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
 

--- a/templates/systemd/funkwhale-watch-imports.service.j2
+++ b/templates/systemd/funkwhale-watch-imports.service.j2
@@ -8,7 +8,7 @@ DefaultDependencies=no
 [Service]
 Type=simple
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} exec {{ funkwhale_api_identifier }} \
-    funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} /srv/funkwhale/data/music --recursive --noinput --in-place --watch {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
+    funkwhale-manage import_files {{ funkwhale_watch_imports_library_id }} {{ funkwhale_api_container_data_path }}/music --recursive --noinput --in-place --watch {{ funkwhale_watch_imports_process_extra_arguments | join(' ') }}
 
 Restart=always
 RestartSec=30


### PR DESCRIPTION
Watches for new tracks and metadata updates in `funkwhale/data/music` and imports them in-place to the specified library. A library needs to be first created and its library ID given in the configuration yml.

Tested and deployed on my personal server, but didn't understand how to make `galaxy/systemd_service_manager` restart the newly added `mash-funkwhale-watch-imports.service`.

Maybe someone can help complete the script?